### PR TITLE
TH-1039 lock timezone

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -131,6 +131,10 @@ USE_L10N = True
 USE_TZ = True
 LANGUAGES = (("fi", _("Finnish")), ("en", _("English")), ("sv", _("Swedish")))
 
+
+WAGTAIL_USER_TIME_ZONES = ['Europe/Helsinki']
+
+
 LOCALE_PATHS = [
     os.path.join(BASE_DIR, 'locale'),
 ]


### PR DESCRIPTION
## Description :sparkles:
Locked time zone on Wagtail so every user will sharing the same Helsinki Timezone.
All previous user should be moved to this timezone automatically, no need to migrate old data

## Issues :bug:
### Closes :no_good_woman:
**[TH-XXX](https://helsinkisolutionoffice.atlassian.net/browse/TH-XXX):**

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
